### PR TITLE
[macos] improve error handling during project init if xcode is missing

### DIFF
--- a/src/apple/system_profile.rs
+++ b/src/apple/system_profile.rs
@@ -57,8 +57,12 @@ impl DeveloperTools {
             },
         )
         .map_err(|ras_err| match ras_err {
-            util::RunAndSearchError::CommandFailed(_) => Error::SystemProfilerCommandFailed(ras_err),
-            util::RunAndSearchError::SearchFailed { .. } => Error::SystemProfilerRegexFailed(ras_err),
+            util::RunAndSearchError::CommandFailed(_) => {
+                Error::SystemProfilerCommandFailed(ras_err)
+            }
+            util::RunAndSearchError::SearchFailed { .. } => {
+                Error::SystemProfilerRegexFailed(ras_err)
+            }
         })?
     }
 }


### PR DESCRIPTION
Hey,

I didn't know that the requirement to install xcode won't be satisfied if I only have macos developer tools.

With this small change, `cargo mobile init` will prompt you specifically with `Is Xcode installed?` if you make the same mistake I made.

I hope this is useful.

Kind regards