### PR TITLE
Improve domain validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,8 +154,8 @@ dependencies = [
  "once-cell-regex 0.2.1",
  "openssl",
  "path_abs",
- "publicsuffix",
  "reserved-names",
+ "rstest",
  "serde",
  "serde_json",
  "structopt",
@@ -356,15 +356,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "error-chain"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d371106cc88ffdfb1eabd7111e432da544f16f3e2d7bf1dfe8bf575f1df045cd"
-dependencies = [
- "version_check",
-]
-
-[[package]]
 name = "fake-simd"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -486,17 +477,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "idna"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9"
-dependencies = [
- "matches",
- "unicode-bidi",
- "unicode-normalization",
-]
-
-[[package]]
 name = "ignore"
 version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -597,12 +577,6 @@ name = "maplit"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
-
-[[package]]
-name = "matches"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 
 [[package]]
 name = "memchr"
@@ -711,12 +685,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "percent-encoding"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
-
-[[package]]
 name = "pest"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -801,19 +769,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "publicsuffix"
-version = "1.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bbaa49075179162b49acac1c6aa45fb4dafb5f13cf6794276d77bc7fd95757b"
-dependencies = [
- "error-chain",
- "idna",
- "lazy_static",
- "regex",
- "url",
-]
-
-[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -852,6 +807,28 @@ version = "0.1.0"
 source = "git+https://github.com/BrainiumLLC/reserved-names#42577c600124e7925d687c68cbf5bb3078aa96ac"
 
 [[package]]
+name = "rstest"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec448bc157977efdc0a71369cf923915b0c4806b1b2449c3fb011071d6f7c38"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -865,6 +842,21 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "semver"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
+dependencies = [
+ "semver-parser",
+]
+
+[[package]]
+name = "semver-parser"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
@@ -908,12 +900,6 @@ dependencies = [
  "fake-simd",
  "opaque-debug",
 ]
-
-[[package]]
-name = "smallvec"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7cb5678e1615754284ec264d9bb5b4c27d2018577fd90ac0ceb578591ed5ee4"
 
 [[package]]
 name = "static_assertions"
@@ -1071,24 +1057,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
-name = "unicode-bidi"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
-dependencies = [
- "matches",
-]
-
-[[package]]
-name = "unicode-normalization"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5479532badd04e128284890390c1e876ef7a993d0570b3597ae43dfa1d59afa4"
-dependencies = [
- "smallvec",
-]
-
-[[package]]
 name = "unicode-segmentation"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1105,17 +1073,6 @@ name = "unicode-xid"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
-
-[[package]]
-name = "url"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "829d4a8476c35c9bf0bbce5a3b23f4106f79728039b726d292bb93bc106787cb"
-dependencies = [
- "idna",
- "matches",
- "percent-encoding",
-]
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,6 @@ java-properties = { version = "1.2.0" }
 log = "0.4.8"
 once-cell-regex = "0.2.1"
 path_abs = "0.5.0"
-publicsuffix = { version = "1.5.4", default-features = false }
 reserved-names = { git = "https://github.com/BrainiumLLC/reserved-names" }
 serde = { version = "1.0.105", features = ["derive"] }
 structopt = "0.3.12"
@@ -44,6 +43,9 @@ textwrap = { version = "0.11.0", features = ["term_size"] }
 thiserror = "1.0.20"
 toml = { version = "0.5.6", features = ["preserve_order"] }
 yes-or-no = { git = "https://github.com/BrainiumLLC/yes-or-no" }
+
+[dev-dependencies]
+rstest = "0.6"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 cocoa = "0.20.0"

--- a/src/config/app/domain.rs
+++ b/src/config/app/domain.rs
@@ -112,7 +112,7 @@ impl fmt::Display for DomainError {
                 label
             ),
             Self::StartsOrEndsWithADot => write!(f, "Domain can't start or end with a dot."),
-            Self::EmptyLabel => write!(f, "Labels cannot be empty."),
+            Self::EmptyLabel => write!(f, "Labels can't be empty."),
         }
     }
 }

--- a/src/config/app/domain.rs
+++ b/src/config/app/domain.rs
@@ -38,7 +38,7 @@ impl fmt::Display for DomainError {
     }
 }
 
-pub fn check_domain_syntax(domain_name: &str) -> Result<&str, DomainError> {
+pub fn check_domain_syntax(domain_name: &str) -> Result<(), DomainError> {
     if domain_name.is_empty() {
         return Err(DomainError::Empty);
     }
@@ -73,7 +73,7 @@ pub fn check_domain_syntax(domain_name: &str) -> Result<&str, DomainError> {
             package_name: last_label.to_owned(),
         });
     }
-    Ok(domain_name)
+    Ok(())
 }
 
 #[cfg(test)]
@@ -89,7 +89,7 @@ mod test {
         case("java.test")
     )]
     fn test_check_domain_syntax_correct(input: &str) {
-        assert_eq!(check_domain_syntax(input).unwrap(), input)
+        assert_eq!(check_domain_syntax(input).unwrap(), ())
     }
 
     #[rstest(input, error,

--- a/src/config/app/domain.rs
+++ b/src/config/app/domain.rs
@@ -67,11 +67,12 @@ pub fn check_domain_syntax(domain_name: &str) -> Result<(), DomainError> {
             return Err(DomainError::NotAsciiAlphanumeric { bad_chars });
         }
     }
-    let last_label = domain_name.split(".").last().unwrap();
-    if RESERVED_PACKAGE_NAMES.contains(&last_label) {
-        return Err(DomainError::ReservedPackageName {
-            package_name: last_label.to_owned(),
-        });
+    for pkg_name in RESERVED_PACKAGE_NAMES.iter() {
+        if domain_name.ends_with(pkg_name) {
+            return Err(DomainError::ReservedPackageName {
+                package_name: pkg_name.to_string(),
+            });
+        }
     }
     Ok(())
 }

--- a/src/config/app/domain.rs
+++ b/src/config/app/domain.rs
@@ -1,0 +1,109 @@
+use std::error::Error;
+use std::fmt;
+
+static RESERVED_PACKAGE_NAMES: [&'static str; 2] = ["kotlin", "java"];
+
+#[derive(Debug)]
+pub enum DomainError {
+    Empty,
+    NotAsciiAlphanumeric { bad_chars: Vec<char> },
+    StartsWithDigit { label: String },
+    ReservedPackageName { package_name: String },
+    StartsOrEndsWithADot,
+    EmptyLabel,
+}
+
+impl Error for DomainError {}
+
+impl fmt::Display for DomainError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Empty => write!(f, "Domain can't be empty"),
+            Self::NotAsciiAlphanumeric { bad_chars } => write!(
+                f,
+                "\"{}\" are not valid ASCII alphanumeric characters",
+                bad_chars.into_iter().collect::<String>()
+            ),
+            Self::ReservedPackageName { package_name } => {
+                write!(f, "\"{}\" is reserved and cannot be used", package_name)
+            }
+            Self::StartsWithDigit { label } => write!(
+                f,
+                "\"{}\" label starts with a digit, which is invalid",
+                label
+            ),
+            Self::StartsOrEndsWithADot => write!(f, "Domain can't start or end with a dot"),
+            Self::EmptyLabel => write!(f, "Labels cannot be empty"),
+        }
+    }
+}
+
+pub fn check_domain_syntax(domain_name: &str) -> Result<&str, DomainError> {
+    if domain_name.is_empty() {
+        return Err(DomainError::Empty);
+    }
+    if domain_name.starts_with(".") || domain_name.ends_with(".") {
+        return Err(DomainError::StartsOrEndsWithADot);
+    }
+    let labels = domain_name.split(".");
+    for label in labels {
+        if label.is_empty() {
+            return Err(DomainError::EmptyLabel);
+        }
+        if label.chars().nth(0).unwrap().is_digit(10) {
+            return Err(DomainError::StartsWithDigit {
+                label: label.to_owned(),
+            });
+        }
+        let mut bad_chars = Vec::new();
+        for c in label.chars() {
+            if !c.is_ascii_alphanumeric() {
+                if !bad_chars.contains(&c) {
+                    bad_chars.push(c);
+                }
+            }
+        }
+        if !bad_chars.is_empty() {
+            return Err(DomainError::NotAsciiAlphanumeric { bad_chars });
+        }
+    }
+    let last_label = domain_name.split(".").last().unwrap();
+    if RESERVED_PACKAGE_NAMES.contains(&last_label) {
+        return Err(DomainError::ReservedPackageName {
+            package_name: last_label.to_owned(),
+        });
+    }
+    Ok(domain_name)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use rstest::rstest;
+
+    #[rstest(
+        input,
+        case("com.example"),
+        case("t2900.e1.s709.t1000"),
+        case("kotlin.com"),
+        case("java.test")
+    )]
+    fn test_check_domain_syntax_correct(input: &str) {
+        assert_eq!(check_domain_syntax(input).unwrap(), input)
+    }
+
+    #[rstest(input, error,
+        case("ラスト.テスト", DomainError::NotAsciiAlphanumeric { bad_chars: vec!['ラ', 'ス', 'ト'] }),
+        case("test.digits.87", DomainError::StartsWithDigit { label: String::from("87") }),
+        case("", DomainError::Empty {}),
+        case(".bad.dot.syntax", DomainError::StartsOrEndsWithADot {}),
+        case("com.kotlin", DomainError::ReservedPackageName { package_name: String::from("kotlin") }),
+        case("com..empty.label", DomainError::EmptyLabel)
+    )]
+    fn test_check_domain_syntax_error(input: &str, error: DomainError) {
+        assert_eq!(
+            check_domain_syntax(input).unwrap_err().to_string(),
+            error.to_string()
+        )
+    }
+}

--- a/src/config/app/mod.rs
+++ b/src/config/app/mod.rs
@@ -1,4 +1,5 @@
 mod common_email_providers;
+pub mod domain;
 pub mod name;
 mod raw;
 
@@ -93,7 +94,7 @@ impl App {
 
         let domain = {
             let domain = raw.domain;
-            if publicsuffix::Domain::has_valid_syntax(&domain) {
+            if domain::check_domain_syntax(&domain).is_ok() {
                 Ok(domain)
             } else {
                 Err(Error::DomainInvalid { domain })

--- a/src/config/app/raw.rs
+++ b/src/config/app/raw.rs
@@ -236,7 +236,7 @@ impl Raw {
             let response = prompt::default("Domain", Some(&defaults.domain), None)
                 .map_err(PromptError::DomainPromptFailed)?;
             match domain::check_domain_syntax(response.as_str()) {
-                Ok(res) => break res.to_owned(),
+                Ok(_) => break response,
                 Err(err) => {
                     println!(
                         "{}",

--- a/src/config/app/raw.rs
+++ b/src/config/app/raw.rs
@@ -240,7 +240,7 @@ impl Raw {
                 Err(err) => {
                     println!(
                         "{}",
-                        wrapper.fill(&format!("Sorry, {}", err)).bright_magenta()
+                        wrapper.fill(&format!("Sorry! {}", err)).bright_magenta()
                     )
                 }
             }

--- a/src/config/app/raw.rs
+++ b/src/config/app/raw.rs
@@ -1,4 +1,4 @@
-use super::{common_email_providers::COMMON_EMAIL_PROVIDERS, name};
+use super::{common_email_providers::COMMON_EMAIL_PROVIDERS, domain, name};
 use crate::{
     templating,
     util::{cli::TextWrapper, prompt, Git},
@@ -29,8 +29,7 @@ fn default_domain() -> Result<Option<String>, DefaultDomainError> {
         .last()
         .ok_or(DefaultDomainError::FailedToParseEmailAddr)?;
     Ok(
-        if !COMMON_EMAIL_PROVIDERS.contains(&domain)
-            && publicsuffix::Domain::has_valid_syntax(&domain)
+        if !COMMON_EMAIL_PROVIDERS.contains(&domain) && domain::check_domain_syntax(&domain).is_ok()
         {
             Some(domain.to_owned())
         } else {
@@ -236,18 +235,14 @@ impl Raw {
         Ok(loop {
             let response = prompt::default("Domain", Some(&defaults.domain), None)
                 .map_err(PromptError::DomainPromptFailed)?;
-            if publicsuffix::Domain::has_valid_syntax(&response) {
-                break response;
-            } else {
-                println!(
-                    "{}",
-                    wrapper
-                        .fill(&format!(
-                            "Sorry, but {:?} isn't valid domain syntax.",
-                            response
-                        ))
-                        .bright_magenta()
-                );
+            match domain::check_domain_syntax(response.as_str()) {
+                Ok(res) => break res.to_owned(),
+                Err(err) => {
+                    println!(
+                        "{}",
+                        wrapper.fill(&format!("Sorry, {}", err)).bright_magenta()
+                    )
+                }
             }
         })
     }


### PR DESCRIPTION
This PR is to fix issues such as #19 
`publicsuffix` domain parsing is not enough to check whether a domain entered by user is valid, java/kotlin do not allow hyphens in their names, digits placed as the first character, underscores etc.
My changes should cover pretty much all the cases. I also disabled reserved package names such as `java` or `kotlin`, but there probably are some more that would break the Android project 