### PR TITLE
Add filter option to android run

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,17 @@ After some straightforward prompts, you'll be asked to select a template pack. T
 | wgpu      | Minimal wgpu project derived from [hello-triangle](https://github.com/gfx-rs/wgpu-rs/tree/master/examples/hello-triangle) example |
 | winit     | Minimal winit project derived from [window](https://github.com/rust-windowing/winit/tree/master/examples/window) example          |
 
+## Android
+
+`cargo android run` will build, install and run the app and follows device logs emitted by the app.
+
+By default, warn and error logs are displayed. Additional logging of increasing verbosity can be shown by use of the `-v` or `-vv` options. These also provide more verbose logging for the build and install steps.
+
+For fine-grained control of logging, use the `--filter` (or `-f`) option, which takes an Android log level, such as `debug`. This option overrides
+the default device logging level set by `-v` or `-vv`.
+
+If using the `android_logger` crate to handle Rust log messages, `trace` logs from Rust are mapped to `verbose` logs in Android.
+
 **Template pack contribution is encouraged**; we'd love to have very nice template packs for Bevy, Amethyst, and whatever else people find helpful! We'll write up a guide for template pack creation soon, but in the mean time, the existing ones are a great reference point. Any template pack placed into `~./cargo-mobile/templates/apps/` will appear as an option in `cargo mobile init`.
 
 Once you've generated your project, you can run `cargo run` as usual to run your app on desktop. However, now you can also do `cargo apple run` and `cargo android run` to run on connected iOS and Android devices respectively!

--- a/README.md
+++ b/README.md
@@ -56,7 +56,15 @@ After some straightforward prompts, you'll be asked to select a template pack. T
 | wgpu      | Minimal wgpu project derived from [hello-triangle](https://github.com/gfx-rs/wgpu-rs/tree/master/examples/hello-triangle) example |
 | winit     | Minimal winit project derived from [window](https://github.com/rust-windowing/winit/tree/master/examples/window) example          |
 
-## Android
+**Template pack contribution is encouraged**; we'd love to have very nice template packs for Bevy, Amethyst, and whatever else people find helpful! We'll write up a guide for template pack creation soon, but in the mean time, the existing ones are a great reference point. Any template pack placed into `~./cargo-mobile/templates/apps/` will appear as an option in `cargo mobile init`.
+
+Once you've generated your project, you can run `cargo run` as usual to run your app on desktop. However, now you can also do `cargo apple run` and `cargo android run` to run on connected iOS and Android devices respectively!
+
+If you prefer to work in the usual IDEs, you can use `cargo apple open` and `cargo android open` to open your project in Xcode and Android Studio respectively.
+
+For more commands, run `cargo mobile`, `cargo apple`, or `cargo android` to see help information.
+
+### Android
 
 `cargo android run` will build, install and run the app and follows device logs emitted by the app.
 
@@ -66,11 +74,3 @@ For fine-grained control of logging, use the `--filter` (or `-f`) option, which 
 the default device logging level set by `-v` or `-vv`.
 
 If using the `android_logger` crate to handle Rust log messages, `trace` logs from Rust are mapped to `verbose` logs in Android.
-
-**Template pack contribution is encouraged**; we'd love to have very nice template packs for Bevy, Amethyst, and whatever else people find helpful! We'll write up a guide for template pack creation soon, but in the mean time, the existing ones are a great reference point. Any template pack placed into `~./cargo-mobile/templates/apps/` will appear as an option in `cargo mobile init`.
-
-Once you've generated your project, you can run `cargo run` as usual to run your app on desktop. However, now you can also do `cargo apple run` and `cargo android run` to run on connected iOS and Android devices respectively!
-
-If you prefer to work in the usual IDEs, you can use `cargo apple open` and `cargo android open` to open your project in Xcode and Android Studio respectively.
-
-For more commands, run `cargo mobile`, `cargo apple`, or `cargo android` to see help information.

--- a/src/android/cli.rs
+++ b/src/android/cli.rs
@@ -66,6 +66,8 @@ pub enum Command {
     Run {
         #[structopt(flatten)]
         profile: cli::Profile,
+        #[structopt(flatten)]
+        filter: cli::Filter,
     },
     #[structopt(name = "st", about = "Displays a detailed stacktrace for a device")]
     Stacktrace,
@@ -209,11 +211,12 @@ impl Exec for Input {
             }),
             Command::Run {
                 profile: cli::Profile { profile },
+                filter: cli::Filter { filter },
             } => with_config(non_interactive, wrapper, |config, _| {
                 ensure_init(config)?;
                 device_prompt(&env)
                     .map_err(Error::DevicePromptFailed)?
-                    .run(config, &env, noise_level, profile)
+                    .run(config, &env, noise_level, profile, filter)
                     .map_err(Error::RunFailed)
             }),
             Command::Stacktrace => with_config(non_interactive, wrapper, |config, _| {

--- a/src/android/device.rs
+++ b/src/android/device.rs
@@ -7,7 +7,7 @@ use super::{
 };
 use crate::{
     env::ExplicitEnv as _,
-    opts::{NoiseLevel, Profile},
+    opts::{NoiseLevel, Profile, FilterLevel},
     util::{
         self,
         cli::{Report, Reportable},
@@ -189,6 +189,7 @@ impl<'a> Device<'a> {
         env: &Env,
         noise_level: NoiseLevel,
         profile: Profile,
+        filter_level: Option<FilterLevel>,
     ) -> Result<(), RunError> {
         self.build_apk(config, env, noise_level, profile)
             .map_err(RunError::ApkBuildFailed)?;
@@ -207,11 +208,11 @@ impl<'a> Device<'a> {
         let filter = format!(
             "{}:{}",
             config.app().name(),
-            match noise_level {
-                NoiseLevel::Polite => "W",
-                NoiseLevel::LoudAndProud => "I",
-                NoiseLevel::FranklyQuitePedantic => "V",
-            },
+            filter_level.unwrap_or(match noise_level {
+                NoiseLevel::Polite => FilterLevel::Warn,
+                NoiseLevel::LoudAndProud => FilterLevel::Info,
+                NoiseLevel::FranklyQuitePedantic => FilterLevel::Verbose,
+            }).logcat()
         );
         adb::adb(env, &self.serial_no)
             .with_args(&["logcat", "-v", "color", "-s", &filter])

--- a/src/android/device.rs
+++ b/src/android/device.rs
@@ -7,7 +7,7 @@ use super::{
 };
 use crate::{
     env::ExplicitEnv as _,
-    opts::{NoiseLevel, Profile, FilterLevel},
+    opts::{FilterLevel, NoiseLevel, Profile},
     util::{
         self,
         cli::{Report, Reportable},
@@ -208,11 +208,13 @@ impl<'a> Device<'a> {
         let filter = format!(
             "{}:{}",
             config.app().name(),
-            filter_level.unwrap_or(match noise_level {
-                NoiseLevel::Polite => FilterLevel::Warn,
-                NoiseLevel::LoudAndProud => FilterLevel::Info,
-                NoiseLevel::FranklyQuitePedantic => FilterLevel::Verbose,
-            }).logcat()
+            filter_level
+                .unwrap_or(match noise_level {
+                    NoiseLevel::Polite => FilterLevel::Warn,
+                    NoiseLevel::LoudAndProud => FilterLevel::Info,
+                    NoiseLevel::FranklyQuitePedantic => FilterLevel::Verbose,
+                })
+                .logcat()
         );
         adb::adb(env, &self.serial_no)
             .with_args(&["logcat", "-v", "color", "-s", &filter])

--- a/src/init.rs
+++ b/src/init.rs
@@ -20,7 +20,7 @@ use std::{
 
 pub static DOT_FIRST_INIT_FILE_NAME: &str = ".first-init";
 static DOT_FIRST_INIT_CONTENTS: &str = // newline
-r#"The presence of this file indicates `cargo mobile init` has been called for
+    r#"The presence of this file indicates `cargo mobile init` has been called for
 the first time on a new project, but hasn't yet completed successfully once. As
 long as this file is here, `cargo mobile init` will use a more aggressive
 template generation strategy that allows it to place files that it wouldn't

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 use yes_or_no::yes_or_no;
+use structopt::clap::arg_enum;
 
 yes_or_no!(NonInteractive);
 
@@ -73,6 +74,31 @@ impl Profile {
         match self {
             Self::Debug => "debug",
             Self::Release => "release",
+        }
+    }
+}
+
+arg_enum! {
+    /// Android device logging filter level, used as an argument for run
+    #[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
+    pub enum FilterLevel {
+        Error,
+        Warn,
+        Info,
+        Debug,
+        Verbose,
+    }
+}
+
+impl FilterLevel {
+    /// Filter level for logcat
+    pub fn logcat(&self) -> &'static str {
+        match self {
+            Self::Error => "E",
+            Self::Warn => "W",
+            Self::Info => "I",
+            Self::Debug => "D",
+            Self::Verbose => "V",
         }
     }
 }

--- a/src/opts.rs
+++ b/src/opts.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
-use yes_or_no::yes_or_no;
 use structopt::clap::arg_enum;
+use yes_or_no::yes_or_no;
 
 yes_or_no!(NonInteractive);
 

--- a/src/util/cli.rs
+++ b/src/util/cli.rs
@@ -35,7 +35,7 @@ pub struct GlobalFlags {
     #[structopt(
         short = "v",
         long = "verbose",
-        help = "Vomit out extensive logging",
+        help = "Vomit out extensive logging (-vv for more)",
         global = true,
         multiple = true,
         parse(from_occurrences = opts::NoiseLevel::from_occurrences),
@@ -79,6 +79,18 @@ pub struct Profile {
         parse(from_flag = opts::Profile::from_flag),
     )]
     pub profile: opts::Profile,
+}
+
+#[derive(Clone, Copy, Debug, StructOpt)]
+pub struct Filter {
+    #[structopt(
+        short = "f",
+        long = "filter",
+        help = "Filter logs by level",
+        possible_values = &opts::FilterLevel::variants(),
+        case_insensitive = true,
+    )]
+    pub filter: Option<opts::FilterLevel>,
 }
 
 pub type TextWrapper = textwrap::Wrapper<'static, textwrap::NoHyphenation>;


### PR DESCRIPTION
Implementation proposal for #28.

* Adds a `-f`/`-filter` option to the run command accepting a case-insensitive Android log level (Error, Warn, Info, Debug, or Verbose). If the filter option is not specified, then `-v`/`-vv` controls the log level displayed during run.