### PR TITLE
Specify library path env var.

### DIFF
--- a/src/apple/cli.rs
+++ b/src/apple/cli.rs
@@ -377,9 +377,9 @@ impl Exec for Input {
                 let mut host_env = HashMap::<&str, &OsStr>::new();
 
                 // Host flags that are used by build scripts
+                let macos_sdk_root =
+                    sdk_root.join("../../../../MacOSX.platform/Developer/SDKs/MacOSX.sdk");
                 let macos_isysroot = {
-                    let macos_sdk_root =
-                        sdk_root.join("../../../../MacOSX.platform/Developer/SDKs/MacOSX.sdk");
                     if !macos_sdk_root.is_dir() {
                         return Err(Error::MacosSdkRootInvalid { macos_sdk_root });
                     }
@@ -399,6 +399,7 @@ impl Exec for Input {
                 let macos_target = Target::macos();
 
                 let isysroot = format!("-isysroot {}", sdk_root.display());
+                let library_path = format!("{}/usr/lib", macos_sdk_root.display());
 
                 for arch in arches {
                     // Set target-specific flags
@@ -414,6 +415,7 @@ impl Exec for Input {
                     target_env.insert(cflags.as_ref(), isysroot.as_ref());
                     target_env.insert(cxxflags.as_ref(), isysroot.as_ref());
                     target_env.insert(objc_include_path.as_ref(), include_dir.as_ref());
+                    target_env.insert("LIBRARY_PATH", library_path.as_ref());
 
                     let target = if macos {
                         &macos_target

--- a/src/apple/cli.rs
+++ b/src/apple/cli.rs
@@ -385,8 +385,6 @@ impl Exec for Input {
                     }
                     (
                         format!("-isysroot {}", macos_sdk_root.display()),
-                        // We need to manually specify a search path to link against the host's libraries for MacOs Big Sur
-                        // https://github.com/signalapp/libsignal-client/commit/02899cac643a14b2ced7c058cc15a836a2165b6d
                         format!("{}/usr/lib", macos_sdk_root.display()),
                     )
                 };
@@ -419,6 +417,8 @@ impl Exec for Input {
                     target_env.insert(cflags.as_ref(), isysroot.as_ref());
                     target_env.insert(cxxflags.as_ref(), isysroot.as_ref());
                     target_env.insert(objc_include_path.as_ref(), include_dir.as_ref());
+                    // Prevents linker errors in build scripts and proc macros:
+                    // https://github.com/signalapp/libsignal-client/commit/02899cac643a14b2ced7c058cc15a836a2165b6d
                     target_env.insert("LIBRARY_PATH", library_path.as_ref());
 
                     let target = if macos {

--- a/src/apple/cli.rs
+++ b/src/apple/cli.rs
@@ -385,6 +385,8 @@ impl Exec for Input {
                     }
                     (
                         format!("-isysroot {}", macos_sdk_root.display()),
+                        // We need to manually specify a search path to link against the host's libraries for MacOs Big Sur
+                        // https://github.com/signalapp/libsignal-client/commit/02899cac643a14b2ced7c058cc15a836a2165b6d
                         format!("{}/usr/lib", macos_sdk_root.display()),
                     )
                 };

--- a/src/apple/cli.rs
+++ b/src/apple/cli.rs
@@ -377,13 +377,16 @@ impl Exec for Input {
                 let mut host_env = HashMap::<&str, &OsStr>::new();
 
                 // Host flags that are used by build scripts
-                let macos_sdk_root =
-                    sdk_root.join("../../../../MacOSX.platform/Developer/SDKs/MacOSX.sdk");
-                let macos_isysroot = {
+                let (macos_isysroot, library_path) = {
+                    let macos_sdk_root =
+                        sdk_root.join("../../../../MacOSX.platform/Developer/SDKs/MacOSX.sdk");
                     if !macos_sdk_root.is_dir() {
                         return Err(Error::MacosSdkRootInvalid { macos_sdk_root });
                     }
-                    format!("-isysroot {}", macos_sdk_root.display())
+                    (
+                        format!("-isysroot {}", macos_sdk_root.display()),
+                        format!("{}/usr/lib", macos_sdk_root.display()),
+                    )
                 };
                 host_env.insert("MAC_FLAGS", macos_isysroot.as_ref());
                 host_env.insert("CFLAGS_x86_64_apple_darwin", macos_isysroot.as_ref());
@@ -399,7 +402,6 @@ impl Exec for Input {
                 let macos_target = Target::macos();
 
                 let isysroot = format!("-isysroot {}", sdk_root.display());
-                let library_path = format!("{}/usr/lib", macos_sdk_root.display());
 
                 for arch in arches {
                     // Set target-specific flags


### PR DESCRIPTION
Fixes `linking with cc` error where cc can't find os libs.