### PR TITLE
fix: should work for m1

### DIFF
--- a/src/apple/target.rs
+++ b/src/apple/target.rs
@@ -143,20 +143,20 @@ impl<'a> TargetTrait<'a> for Target<'a> {
                     min_xcode_version: None,
                 },
             );
-            targets.insert(
-                "x86_64",
-                Target {
-                    triple: "x86_64-apple-ios",
-                    arch: "x86_64",
-                    alias: None,
-                    // Simulator only supports Metal as of Xcode 11.0:
-                    // https://developer.apple.com/documentation/metal/developing_metal_apps_that_run_in_simulator?language=objc
-                    // While this doesn't matter if you aren't using Metal,
-                    // it should be fine to be opinionated about this given
-                    // OpenGL's deprecation.
-                    min_xcode_version: Some(((11, 0), "iOS Simulator doesn't support Metal until")),
-                },
-            );
+            // targets.insert(
+            //     "aarc",
+            //     Target {
+            //         triple: "x86_64-apple-ios",
+            //         arch: "x86_64",
+            //         alias: None,
+            //         // Simulator only supports Metal as of Xcode 11.0:
+            //         // https://developer.apple.com/documentation/metal/developing_metal_apps_that_run_in_simulator?language=objc
+            //         // While this doesn't matter if you aren't using Metal,
+            //         // it should be fine to be opinionated about this given
+            //         // OpenGL's deprecation.
+            //         min_xcode_version: Some(((11, 0), "iOS Simulator doesn't support Metal until")),
+            //     },
+            // );
             targets
         })
     }

--- a/templates/platforms/xcode/project.yml.hbs
+++ b/templates/platforms/xcode/project.yml.hbs
@@ -69,10 +69,10 @@ targets:
     settings:
       base:
         ENABLE_BITCODE: false
-        ARCHS: [arm64, x86_64] # rustc doesn't support arm64e yet
-        VALID_ARCHS: arm64 x86_64 # rustc doesn't support arm64e yet
+        ARCHS: [arm64] # rustc doesn't support arm64e yet
+        VALID_ARCHS: arm64 # rustc doesn't support arm64e yet
         LIBRARY_SEARCH_PATHS[sdk=iphoneos*]: $(inherited) "{{prefix-path "target/aarch64-apple-ios/$(CONFIGURATION)"}}"
-        LIBRARY_SEARCH_PATHS[sdk=iphonesimulator*]: $(inherited) "{{prefix-path "target/x86_64-apple-ios/$(CONFIGURATION)"}}"
+        LIBRARY_SEARCH_PATHS[sdk=iphonesimulator*]: $(inherited) "{{prefix-path "target/aarch64-apple-ios-sim/$(CONFIGURATION)"}}"
         ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES: true
       groups: [app]
     dependencies:


### PR DESCRIPTION
This adjusts some targets to get cargo-mobile working on macOS with Apple Silicon.

NOTE: Currently, the changes here *only* work for m1. I have not made any adjustments to adopt both platforms. I plan to get that working sometime in the future, so this PR is just mainly to provide others looking for M1 support a fork to install from.

