### PR TITLE
Add open xcode with xed command

### DIFF
--- a/src/apple/cli.rs
+++ b/src/apple/cli.rs
@@ -249,7 +249,7 @@ impl Exec for Input {
         }
 
         fn open_in_xcode(config: &Config) -> Result<(), Error> {
-            os::open_file_with("Xcode", config.project_dir()).map_err(Error::OpenFailed)
+            os::open_in_xcode(config.project_dir()).map_err(Error::OpenFailed)
         }
 
         let version_check = || rust_version_check(wrapper).map_err(Error::RustVersionCheckFailed);

--- a/src/os/macos/mod.rs
+++ b/src/os/macos/mod.rs
@@ -104,6 +104,13 @@ pub fn open_file_with(
     Ok(())
 }
 
+pub fn open_in_xcode(path: impl AsRef<OsStr>) -> bossy::Result<()> {
+    bossy::Command::impure("xed")
+        .with_arg(path.as_ref())
+        .run_and_wait()?;
+    Ok(())
+}
+
 #[cfg(target_os = "macos")]
 pub fn command_path(name: &str) -> bossy::Result<bossy::Output> {
     bossy::Command::impure("command")


### PR DESCRIPTION
## PR checklist

- [x] Has Xcode been invocation?

## What is `xed`

`xed` is the way to launch using Xcode, which the system recognizes as the default. (Able to use `xcode-select -p` to see which Xcode is recognized as default).
It is installed if xcode is installed in the MacOS environment.

Starting with the name `Xcode` may fail. For example, if you have multiple Xcode versions installed, they are named `Xcode-13.x`, `Xcode-12.x`, and so on. Therefore `open -a Xcode` will fail.

xed is a kind of wrapper for the open command that opens Xcode as recognized by the system. This is very robust and useful, because it allows developers to find whatever development environment they are in.