### PR TITLE
Forward env vars from mobile.toml to .cargo/config.toml

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -104,6 +104,7 @@ pub struct Config {
     #[cfg(target_os = "macos")]
     apple: apple::config::Config,
     android: android::config::Config,
+    env: Option<toml::value::Table>,
 }
 
 impl Config {
@@ -119,6 +120,7 @@ impl Config {
             #[cfg(target_os = "macos")]
             apple,
             android,
+            env: raw.env,
         })
     }
 
@@ -178,6 +180,10 @@ impl Config {
 
     pub fn android(&self) -> &android::config::Config {
         &self.android
+    }
+
+    pub fn env(&self) -> &Option<toml::value::Table> {
+        &self.env
     }
 
     pub fn build_a_bike(&self) -> bicycle::Bicycle {

--- a/src/config/raw.rs
+++ b/src/config/raw.rs
@@ -109,6 +109,7 @@ pub struct Raw {
     #[cfg(target_os = "macos")]
     pub apple: Option<apple::config::Raw>,
     pub android: Option<android::config::Raw>,
+    pub env: Option<toml::value::Table>,
 }
 
 impl Raw {
@@ -121,6 +122,7 @@ impl Raw {
             #[cfg(target_os = "macos")]
             apple: Some(apple),
             android: None,
+            env: None,
         })
     }
 
@@ -133,6 +135,7 @@ impl Raw {
             #[cfg(target_os = "macos")]
             apple: Some(apple),
             android: None,
+            env: None,
         })
     }
 

--- a/src/dot_cargo.rs
+++ b/src/dot_cargo.rs
@@ -107,6 +107,7 @@ pub struct DotCargo {
     target: BTreeMap<String, DotCargoTarget>,
     #[serde(flatten)]
     extra: BTreeMap<String, Value>,
+    env: Option<toml::value::Table>,
 }
 
 impl DotCargo {
@@ -145,6 +146,10 @@ impl DotCargo {
 
     pub fn set_default_target(&mut self, target: impl Into<String>) {
         self.build = Some(DotCargoBuild::new(target));
+    }
+
+    pub fn set_env(&mut self, env: &Option<toml::value::Table>) {
+        self.env = env.clone()
     }
 
     pub fn insert_target(&mut self, name: impl Into<String>, target: DotCargoTarget) {

--- a/src/dot_cargo.rs
+++ b/src/dot_cargo.rs
@@ -148,8 +148,8 @@ impl DotCargo {
         self.build = Some(DotCargoBuild::new(target));
     }
 
-    pub fn set_env(&mut self, env: &Option<toml::value::Table>) {
-        self.env = env.clone()
+    pub fn set_env(&mut self, env: Option<toml::value::Table>) {
+        self.env = env
     }
 
     pub fn insert_target(&mut self, name: impl Into<String>, target: DotCargoTarget) {

--- a/src/init.rs
+++ b/src/init.rs
@@ -166,7 +166,7 @@ pub fn exec(
         util::host_target_triple().map_err(Error::HostTargetTripleDetectionFailed)?,
     );
 
-    dot_cargo.set_env(config.env());
+    dot_cargo.set_env(config.env().clone());
 
     let metadata = Metadata::load(&config.app().root_dir()).map_err(Error::MetadataFailed)?;
 

--- a/src/init.rs
+++ b/src/init.rs
@@ -166,6 +166,8 @@ pub fn exec(
         util::host_target_triple().map_err(Error::HostTargetTripleDetectionFailed)?,
     );
 
+    dot_cargo.set_env(config.env());
+
     let metadata = Metadata::load(&config.app().root_dir()).map_err(Error::MetadataFailed)?;
 
     // Generate Xcode project


### PR DESCRIPTION
Since cargo mobile overwrites .cargo/config.toml, this allows users to specify the [env] table in mobile.toml instead. Then the table is moved into .cargo/config.toml on init