### PR TITLE
feat(android/run): add an option to specify android activity

### DIFF
--- a/src/android/cli.rs
+++ b/src/android/cli.rs
@@ -70,6 +70,13 @@ pub enum Command {
         filter: cli::Filter,
         #[structopt(flatten)]
         reinstall_deps: cli::ReinstallDeps,
+        #[structopt(
+            short = "a",
+            long = "activity",
+            default_value = "android.app.NativeActivity",
+            help = "Specifies which activtiy to launch"
+        )]
+        activity: String,
     },
     #[structopt(name = "st", about = "Displays a detailed stacktrace for a device")]
     Stacktrace,
@@ -215,6 +222,7 @@ impl Exec for Input {
                 profile: cli::Profile { profile },
                 filter: cli::Filter { filter },
                 reinstall_deps: cli::ReinstallDeps { reinstall_deps },
+                activity,
             } => with_config(non_interactive, wrapper, |config, metadata| {
                 let build_app_bundle = metadata.asset_packs().is_some();
                 ensure_init(config)?;
@@ -228,6 +236,7 @@ impl Exec for Input {
                         filter,
                         build_app_bundle,
                         reinstall_deps,
+                        activity,
                     )
                     .map_err(Error::RunFailed)
             }),

--- a/src/android/device.rs
+++ b/src/android/device.rs
@@ -323,6 +323,7 @@ impl<'a> Device<'a> {
         filter_level: Option<FilterLevel>,
         build_app_bundle: bool,
         reinstall_deps: opts::ReinstallDeps,
+        activity: String,
     ) -> Result<(), RunError> {
         if build_app_bundle {
             bundletool::install(reinstall_deps).map_err(RunError::BundletoolInstallFailed)?;
@@ -341,9 +342,10 @@ impl<'a> Device<'a> {
                 .map_err(RunError::ApkInstallFailed)?;
         }
         let activity = format!(
-            "{}.{}/android.app.NativeActivity",
+            "{}.{}/{}",
             config.app().reverse_domain(),
             config.app().name_snake(),
+            activity,
         );
         self.adb(env)
             .with_args(&["shell", "am", "start", "-n", &activity])


### PR DESCRIPTION
I am using a custom template where the activity name is the default android name `.MainActivity`, with this PR I can just do `cargo android run -a .MainActivity`
I kept the old activity name as the default so the default behaviour isn't changed.